### PR TITLE
[WIP] BridgeTx generic structure

### DIFF
--- a/go/extensions/codec.go
+++ b/go/extensions/codec.go
@@ -1,16 +1,15 @@
 package extensions
 
 import (
-	bridge "github.com/cosmos/amino-js/go/lib/bridge"
 	amino "github.com/tendermint/go-amino"
 )
 
 func RegisterCodec(codec *amino.Codec) {
 	codec.RegisterConcrete(TxCreateMarket{}, "microtick/CreateMarket", nil)
-	codec.RegisterConcrete(TxBridgeEventData{}, "bridge/TxBridgeEventData", nil)
-	codec.RegisterConcrete(bridge.MsgTransfer{}, "bridge/MsgTransfer", nil)
-	codec.RegisterConcrete(bridge.MsgSender{}, "bridge/MsgSender", nil)
-	codec.RegisterConcrete(bridge.MsgModule{}, "bridge/MsgModule", nil)
-	codec.RegisterConcrete(bridge.MsgBurn{}, "bridge/MsgBurn", nil)
-	codec.RegisterConcrete(bridge.MsgAction{}, "bridge/MsgAction", nil)
+	codec.RegisterConcrete(BridgeTx{}, "bridge/BridgeTx", nil)
+	codec.RegisterConcrete(MsgTransfer{}, "bridge/MsgTransfer", nil)
+	codec.RegisterConcrete(MsgSender{}, "bridge/MsgSender", nil)
+	codec.RegisterConcrete(MsgModule{}, "bridge/MsgModule", nil)
+	codec.RegisterConcrete(MsgBurn{}, "bridge/MsgBurn", nil)
+	codec.RegisterConcrete(MsgAction{}, "bridge/MsgAction", nil)
 }

--- a/go/extensions/codec.go
+++ b/go/extensions/codec.go
@@ -1,9 +1,16 @@
 package extensions
 
 import (
+	bridge "github.com/cosmos/amino-js/go/lib/bridge"
 	amino "github.com/tendermint/go-amino"
 )
 
 func RegisterCodec(codec *amino.Codec) {
 	codec.RegisterConcrete(TxCreateMarket{}, "microtick/CreateMarket", nil)
+	codec.RegisterConcrete(TxBridgeEventData{}, "bridge/TxBridgeEventData", nil)
+	codec.RegisterConcrete(bridge.MsgTransfer{}, "bridge/MsgTransfer", nil)
+	codec.RegisterConcrete(bridge.MsgSender{}, "bridge/MsgSender", nil)
+	codec.RegisterConcrete(bridge.MsgModule{}, "bridge/MsgModule", nil)
+	codec.RegisterConcrete(bridge.MsgBurn{}, "bridge/MsgBurn", nil)
+	codec.RegisterConcrete(bridge.MsgAction{}, "bridge/MsgAction", nil)
 }

--- a/go/extensions/codec.go
+++ b/go/extensions/codec.go
@@ -5,7 +5,6 @@ import (
 )
 
 func RegisterCodec(codec *amino.Codec) {
-	codec.RegisterConcrete(TxCreateMarket{}, "microtick/CreateMarket", nil)
 	codec.RegisterConcrete(BridgeTx{}, "bridge/BridgeTx", nil)
 	codec.RegisterConcrete(MsgTransfer{}, "bridge/MsgTransfer", nil)
 	codec.RegisterConcrete(MsgSender{}, "bridge/MsgSender", nil)

--- a/go/extensions/go.sum
+++ b/go/extensions/go.sum
@@ -1,5 +1,6 @@
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d h1:yJzD/yFppdVCf6ApMkVy8cUxV0XrxdP9rVf6D87/Mng=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
+github.com/cosmos/amino-js v0.6.2 h1:YWaXGgkMk03WDay3u4YikpziBzTNfYGHxgNsYowgyLk=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go/extensions/types.go
+++ b/go/extensions/types.go
@@ -1,8 +1,10 @@
 package extensions
 
 import (
+	bridge "github.com/cosmos/amino-js/go/lib/bridge/types"
 	sdk "github.com/cosmos/amino-js/go/lib/cosmos/cosmos-sdk/types"
-	abci "github.com/cosmos/amino-js/go/lib/tendermint/tendermint/abci/types"
+	"github.com/cosmos/amino-js/go/lib/tendermint/tendermint/libs/common"
+	tm "github.com/cosmos/amino-js/go/lib/tendermint/tendermint/types"
 )
 
 var _ sdk.Msg = (*TxCreateMarket)(nil)
@@ -12,17 +14,62 @@ type TxCreateMarket struct {
 	Market  string
 }
 
-var _ sdk.Tx = (*TxBridgeEventData)(nil)
+var _ sdk.Tx = (*BridgeTx)(nil)
 
-type TxBridgeEventData struct {
-	TxResult
+type BridgeTx struct {
+	Hash     string           `json:"hash"`
+	Height   int64            `json:"height"`
+	Index    uint32           `json:"index"`
+	TxResult BridgeResponseTx `json:"tx_result"`
+	Tx       tm.Tx            `json:"tx"`
 }
 
-type TxResult struct {
-	Height int64                  `json:"height"`
-	Index  uint32                 `json:"index"`
-	Tx     Tx                     `json:"tx"`
-	Result abci.ResponseDeliverTx `json:"result"`
+type BridgeResponseTx struct {
+	Code                 uint32          `protobuf:"varint,1,opt,name=code,proto3" json:"code,omitempty"`
+	Data                 []byte          `protobuf:"bytes,2,opt,name=data,proto3" json:"data,omitempty"`
+	Log                  string          `protobuf:"bytes,3,opt,name=log,proto3" json:"log,omitempty"`
+	Info                 string          `protobuf:"bytes,4,opt,name=info,proto3" json:"info,omitempty"`
+	GasWanted            int64           `protobuf:"varint,5,opt,name=gas_wanted,json=gasWanted,proto3" json:"gas_wanted,omitempty"`
+	GasUsed              int64           `protobuf:"varint,6,opt,name=gas_used,json=gasUsed,proto3" json:"gas_used,omitempty"`
+	Events               []common.KVPair `protobuf:"bytes,7,rep,name=events" json:"events,omitempty"`
+	Codespace            string          `protobuf:"bytes,8,opt,name=codespace,proto3" json:"codespace,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}        `json:"-"`
+	XXX_unrecognized     []byte          `json:"-"`
+	XXX_sizecache        int32           `json:"-"`
 }
 
-type Tx []byte
+var _ sdk.Msg = (*MsgBurn)(nil)
+
+type MsgBurn struct {
+	Amount           sdk.Coins              `json:"amount,omitempty"`
+	CosmosSender     sdk.AccAddress         `json:"cosmos_sender,omitempty"`
+	EthereumChainID  int                    `json:"ethereum_chain_id,omitempty"`
+	EthereumReceiver bridge.EthereumAddress `json:"ethereum_receiver,omitempty"`
+	TokenContract    bridge.EthereumAddress `json:"token_contract,omitempty"` // TODO: update to `json:"token_contract_address"`
+}
+
+var _ sdk.Msg = (*MsgAction)(nil)
+
+type MsgAction struct {
+	Action string `json:"action"`
+}
+
+var _ sdk.Msg = (*MsgTransfer)(nil)
+
+type MsgTransfer struct {
+	Recipient sdk.AccAddress `json:"recipient"`
+	Amount    sdk.Coins      `json:"amount"`
+}
+
+var _ sdk.Msg = (*MsgSender)(nil)
+
+type MsgSender struct {
+	Sender sdk.AccAddress `json:"sender"`
+}
+
+var _ sdk.Msg = (*MsgModule)(nil)
+
+type MsgModule struct {
+	Module string         `json:"module"`
+	Sender sdk.AccAddress `json:"sender"`
+}

--- a/go/extensions/types.go
+++ b/go/extensions/types.go
@@ -1,12 +1,28 @@
 package extensions
 
 import (
-    sdk "github.com/cosmos/amino-js/go/lib/cosmos/cosmos-sdk/types"
+	sdk "github.com/cosmos/amino-js/go/lib/cosmos/cosmos-sdk/types"
+	abci "github.com/cosmos/amino-js/go/lib/tendermint/tendermint/abci/types"
 )
 
 var _ sdk.Msg = (*TxCreateMarket)(nil)
 
 type TxCreateMarket struct {
-   Account sdk.AccAddress
-   Market string
+	Account sdk.AccAddress
+	Market  string
 }
+
+var _ sdk.Tx = (*TxBridgeEventData)(nil)
+
+type TxBridgeEventData struct {
+	TxResult
+}
+
+type TxResult struct {
+	Height int64                  `json:"height"`
+	Index  uint32                 `json:"index"`
+	Tx     Tx                     `json:"tx"`
+	Result abci.ResponseDeliverTx `json:"result"`
+}
+
+type Tx []byte

--- a/go/extensions/types.go
+++ b/go/extensions/types.go
@@ -7,13 +7,6 @@ import (
 	tm "github.com/cosmos/amino-js/go/lib/tendermint/tendermint/types"
 )
 
-var _ sdk.Msg = (*TxCreateMarket)(nil)
-
-type TxCreateMarket struct {
-	Account sdk.AccAddress
-	Market  string
-}
-
 var _ sdk.Tx = (*BridgeTx)(nil)
 
 type BridgeTx struct {
@@ -25,17 +18,14 @@ type BridgeTx struct {
 }
 
 type BridgeResponseTx struct {
-	Code                 uint32          `protobuf:"varint,1,opt,name=code,proto3" json:"code,omitempty"`
-	Data                 []byte          `protobuf:"bytes,2,opt,name=data,proto3" json:"data,omitempty"`
-	Log                  string          `protobuf:"bytes,3,opt,name=log,proto3" json:"log,omitempty"`
-	Info                 string          `protobuf:"bytes,4,opt,name=info,proto3" json:"info,omitempty"`
-	GasWanted            int64           `protobuf:"varint,5,opt,name=gas_wanted,json=gasWanted,proto3" json:"gas_wanted,omitempty"`
-	GasUsed              int64           `protobuf:"varint,6,opt,name=gas_used,json=gasUsed,proto3" json:"gas_used,omitempty"`
-	Events               []common.KVPair `protobuf:"bytes,7,rep,name=events" json:"events,omitempty"`
-	Codespace            string          `protobuf:"bytes,8,opt,name=codespace,proto3" json:"codespace,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}        `json:"-"`
-	XXX_unrecognized     []byte          `json:"-"`
-	XXX_sizecache        int32           `json:"-"`
+	Code      uint32          `protobuf:"varint,1,opt,name=code,proto3" json:"code,omitempty"`
+	Data      []byte          `protobuf:"bytes,2,opt,name=data,proto3" json:"data,omitempty"`
+	Log       string          `protobuf:"bytes,3,opt,name=log,proto3" json:"log,omitempty"`
+	Info      string          `protobuf:"bytes,4,opt,name=info,proto3" json:"info,omitempty"`
+	GasWanted int64           `protobuf:"varint,5,opt,name=gas_wanted,json=gasWanted,proto3" json:"gas_wanted,omitempty"`
+	GasUsed   int64           `protobuf:"varint,6,opt,name=gas_used,json=gasUsed,proto3" json:"gas_used,omitempty"`
+	Events    []common.KVPair `protobuf:"bytes,7,rep,name=events" json:"events,omitempty"`
+	Codespace string          `protobuf:"bytes,8,opt,name=codespace,proto3" json:"codespace,omitempty"`
 }
 
 var _ sdk.Msg = (*MsgBurn)(nil)

--- a/go/lib/bridge/msgs.go
+++ b/go/lib/bridge/msgs.go
@@ -1,0 +1,32 @@
+package bridge
+
+import (
+	"github.com/cosmos/amino-js/go/lib/bridge/types"
+	sdk "github.com/cosmos/amino-js/go/lib/cosmos/cosmos-sdk/types"
+)
+
+type MsgTransfer struct {
+	Recipient sdk.AccAddress `json:"recipient"`
+	Amount    sdk.Coins      `json:"amount"`
+}
+
+type MsgSender struct {
+	Sender sdk.AccAddress `json:"sender"`
+}
+
+type MsgModule struct {
+	Module string         `json:"module"`
+	Sender sdk.AccAddress `json:"sender"`
+}
+
+type MsgBurn struct {
+	EthereumChainID  int                   `json:"ethereum_chain_id"`
+	TokenContract    types.EthereumAddress `json:"token_contract"`
+	CosmosSender     sdk.AccAddress        `json:"cosmos_sender"`
+	EthereumReceiver types.EthereumAddress `json:"ethereum_receiver"`
+	Amount           sdk.Coins             `json:"amount"`
+}
+
+type MsgAction struct {
+	Action string `json:"action"`
+}

--- a/go/lib/bridge/types/claim.go
+++ b/go/lib/bridge/types/claim.go
@@ -1,0 +1,3 @@
+package types
+
+type ClaimType int

--- a/go/lib/bridge/types/ethereum.go
+++ b/go/lib/bridge/types/ethereum.go
@@ -1,0 +1,9 @@
+package types
+
+// AddressLength is the expected length of the address
+const AddressLength = 20
+
+// Address represents the 20 byte address of an Ethereum account.
+type Address [AddressLength]byte
+
+type EthereumAddress Address

--- a/lib/Amino.d.ts
+++ b/lib/Amino.d.ts
@@ -1534,6 +1534,17 @@ export function encodeMockRandomGoodEvidence (json: JSONBytes, lengthPrefixed: b
  */
 export function encodeMockBadEvidence (json: JSONBytes, lengthPrefixed: boolean): AminoBytes;
 
+/**
+ * Encode a `BridgeTx` object from JSON to Amino
+ *
+ * @param   json           - binary JSON-encoded `BridgeTx` object
+ * @param   lengthPrefixed - if `true`, use length-prefixed Amino encoding; if `false`, use bare Amino encoding
+ *
+ * @returns binary Amino-encoded `BridgeTx` object
+ * @throws  will throw if encoding fails
+ */
+export function encodeBridgeTx (json: JSONBytes, lengthPrefixed: boolean): AminoBytes;
+
 // Typed decoding
 /**
  * Decode a `MultiStoreProofOp` object from Amino to JSON
@@ -2656,3 +2667,25 @@ export function decodeMockRandomGoodEvidence (amino: AminoBytes, lengthPrefixed:
  * @throws  will throw if decoding fails
  */
 export function decodeMockBadEvidence (amino: AminoBytes, lengthPrefixed: boolean): JSONBytes;
+
+/**
+ * Decode a `BridgeTx` object from Amino to JSON
+ *
+ * @param   amino          - binary Amino-encoded `object ` object
+ * @param   lengthPrefixed - if true, use length-prefixed Amino decoding; if false, use bare Amino decoding
+ *
+ * @returns binary JSON-encoded `BridgeTx` object
+ * @throws  will throw if decoding fails
+ */
+export function decodeBridgeTx (amino: AminoBytes, lengthPrefixed: boolean): JSONBytes;
+
+// /**
+//  * Decode a `decodeMsgBurn` object from Amino to JSON
+//  *
+//  * @param   amino          - binary Amino-encoded `decodeMsgBurn` object
+//  * @param   lengthPrefixed - if true, use length-prefixed Amino decoding; if false, use bare Amino decoding
+//  *
+//  * @returns binary JSON-encoded `decodeMsgBurn` object
+//  * @throws  will throw if decoding fails
+//  */
+// export function decodeMsgBurn (amino: AminoBytes, lengthPrefixed: boolean): JSONBytes;

--- a/lib/Amino.d.ts
+++ b/lib/Amino.d.ts
@@ -2678,14 +2678,3 @@ export function decodeMockBadEvidence (amino: AminoBytes, lengthPrefixed: boolea
  * @throws  will throw if decoding fails
  */
 export function decodeBridgeTx (amino: AminoBytes, lengthPrefixed: boolean): JSONBytes;
-
-// /**
-//  * Decode a `decodeMsgBurn` object from Amino to JSON
-//  *
-//  * @param   amino          - binary Amino-encoded `decodeMsgBurn` object
-//  * @param   lengthPrefixed - if true, use length-prefixed Amino decoding; if false, use bare Amino decoding
-//  *
-//  * @returns binary JSON-encoded `decodeMsgBurn` object
-//  * @throws  will throw if decoding fails
-//  */
-// export function decodeMsgBurn (amino: AminoBytes, lengthPrefixed: boolean): JSONBytes;

--- a/src/decodeType.ts
+++ b/src/decodeType.ts
@@ -102,5 +102,4 @@ export {
     decodeMockRandomGoodEvidence,
     decodeMockBadEvidence,
     decodeBridgeTx
-    // decodeMsgBurn
 } from '../lib/Amino';

--- a/src/decodeType.ts
+++ b/src/decodeType.ts
@@ -100,5 +100,7 @@ export {
     decodeDuplicateVoteEvidence,
     decodeMockGoodEvidence,
     decodeMockRandomGoodEvidence,
-    decodeMockBadEvidence
+    decodeMockBadEvidence,
+    decodeBridgeTx
+    // decodeMsgBurn
 } from '../lib/Amino';

--- a/src/encodeType.ts
+++ b/src/encodeType.ts
@@ -100,5 +100,6 @@ export {
     encodeDuplicateVoteEvidence,
     encodeMockGoodEvidence,
     encodeMockRandomGoodEvidence,
-    encodeMockBadEvidence
+    encodeMockBadEvidence,
+    encodeBridgeTx
 } from '../lib/Amino';

--- a/src/marshalType.ts
+++ b/src/marshalType.ts
@@ -102,7 +102,8 @@ import {
     VoteMessage,
     VoteSetBitsMessage,
     VoteSetMaj23Message,
-    WALMessage
+    WALMessage,
+    BridgeTx
 } from './types';
 import { marshalJSON } from './util';
 
@@ -1532,4 +1533,18 @@ export function marshalMockRandomGoodEvidence (o: MockRandomGoodEvidence, length
 export function marshalMockBadEvidence (o: MockBadEvidence, lengthPrefixed: boolean = true): AminoBytes {
     const json = marshalJSON(o);
     return encodeType.encodeMockBadEvidence(json, lengthPrefixed);
+}
+
+/**
+ * Marshal a `BridgeTx` object to Amino
+ *
+ * @param   o              - `BridgeTx` object
+ * @param   lengthPrefixed - if `true`, use length-prefixed Amino encoding; if `false`, use bare Amino encoding
+ *
+ * @returns binary Amino-encoded `BridgeTx` object
+ * @throws  will throw if encoding fails
+ */
+export function marshalBridgeTx (o: BridgeTx, lengthPrefixed: boolean = true): AminoBytes {
+    const json = marshalJSON(o);
+    return encodeType.encodeBridgeTx(json, lengthPrefixed);
 }

--- a/src/types/bridge.ts
+++ b/src/types/bridge.ts
@@ -1,0 +1,46 @@
+export interface BridgeTx extends BridgeTxResult {
+}
+
+export interface BridgeTxResult {
+    hash:     string;
+    height:   string;
+    index:    number;
+    tx_result: BridgeResponseTx;
+    tx:       string;
+}
+
+export interface BridgeResponseTx {
+    code:                 number;
+    data?:                 null;         
+    log?:                  string;        
+    info?:                 string;          
+    gasWanted:            string;          
+    gasUsed:              string;          
+    events:               BridgeMsg[];
+    codespace:            string;
+    XXX_NoUnkeyedLiteral?: string;
+    XXX_unrecognized?:     string;
+    XXX_sizecache?:        string;
+}
+
+interface BridgeMsg {
+}
+
+export interface MsgBurn extends BridgeMsg {
+}
+
+export interface MsgAction extends BridgeMsg {
+
+}
+
+export interface MsgTransfer extends BridgeMsg {
+
+}
+
+export interface MsgSender extends BridgeMsg {
+
+}
+
+export interface MsgModule extends BridgeMsg {
+
+}

--- a/src/types/bridge.ts
+++ b/src/types/bridge.ts
@@ -18,9 +18,6 @@ export interface BridgeResponseTx {
     gasUsed:              string;          
     events:               BridgeMsg[];
     codespace:            string;
-    XXX_NoUnkeyedLiteral?: string;
-    XXX_unrecognized?:     string;
-    XXX_sizecache?:        string;
 }
 
 interface BridgeMsg {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,7 @@
 export * from './auth';
 export * from './bank';
 export * from './blockchain';
+export * from './bridge';
 export * from './conn';
 export * from './consensus';
 export * from './crisis';

--- a/src/unmarshalType.ts
+++ b/src/unmarshalType.ts
@@ -102,7 +102,8 @@ import {
     VoteMessage,
     VoteSetBitsMessage,
     VoteSetMaj23Message,
-    WALMessage
+    WALMessage,
+    BridgeTx
 } from './types';
 import { unmarshalJSON } from './util';
 
@@ -1531,5 +1532,19 @@ export function unmarshalMockRandomGoodEvidence (amino: AminoBytes, lengthPrefix
  */
 export function unmarshalMockBadEvidence (amino: AminoBytes, lengthPrefixed: boolean = true): MockBadEvidence {
     const json = decodeType.decodeMockBadEvidence(amino, lengthPrefixed);
+    return unmarshalJSON(json);
+}
+
+/**
+ * Unmarshal a `BridgeTx` object from Amino
+ *
+ * @param   amino          - binary Amino-encoded `BridgeTx` object
+ * @param   lengthPrefixed - if true, use length-prefixed Amino decoding; if false, use bare Amino decoding
+ *
+ * @returns `BridgeTx` object
+ * @throws  will throw if decoding fails
+ */
+export function unmarshalBridgeTx (amino: AminoBytes, lengthPrefixed: boolean = true): BridgeTx {
+    const json = decodeType.decodeBridgeTx(amino, lengthPrefixed);
     return unmarshalJSON(json);
 }

--- a/test/extensions.test.ts
+++ b/test/extensions.test.ts
@@ -29,6 +29,50 @@ const tx = {
     }
 };
 
+const burnTxData = 'zAEoKBapClSA/od3CAMSFGgsKuQFPqxkzxuqoExzlwPcBD8KGhQDpuUMvbeLSOsVaBY12UH6p/EEFyIUe5W27H69c1cimM7zK7VPpAggc1kqCgoFc3Rha2USATESBBDAmgwaagom61rphyEC0neOjVPEzT6uSqIkOYLH9TThHOe9IxzDiOYjrESyHNQSQFW9x/BGAspiIzqRjl0UHP8lKXVNFJ3sop/sZBNmUnYcWmz//FVR5fsKuW5nDyh/MV9g6iQxBWoPabv62X8Ekbw=';
+
+const burnTx = {
+    'type':  'bridge/TxBridgeEventData',
+    'value': {
+        'msg':        [{
+            'type':  'bridge/MsgTransfer',
+            'value': {
+                'recipient': 'cosmos1l3dftf499u4gvdeuuzdl2pgv4f0xdtnuens5wv',
+                'amount':  '1stake'
+            }
+        },
+        {
+            'type':  'bridge/MsgSender',
+            'value': {
+                'sender': 'cosmos1qwnw2r9ak79536c4dqtrtk2pl2nlzpqh763rls'      
+            }
+        },
+        {
+            'type':  'bridge/MsgModule',
+            'value': {
+                'module': 'ethbridge',      
+                'sender': 'cosmos1qwnw2r9ak79536c4dqtrtk2pl2nlzpqh763rls'      
+            }
+        },
+        {
+            'type':  'bridge/MsgBurn',
+            'value': {
+                'EthereumChainID': '3',
+                'TokenContract':  '0x682c2AE4053Eac64cF1BAaA04C739703Dc043F0A',
+                'CosmosSender':  'cosmos1qwnw2r9ak79536c4dqtrtk2pl2nlzpqh763rls',
+                'EthereumReceiver':  '0x7B95B6EC7EbD73572298cEf32Bb54FA408207359',
+                'Amount':  '1stake'
+            }
+        },
+        {
+            'type':  'bridge/MsgAction',
+            'value': {
+                'action': 'burn' 
+            }
+        }]
+    }
+};
+
 describe('Extensions', () => {
     describe('decoding', () => {
         describe('Tx', () => {
@@ -36,6 +80,14 @@ describe('Extensions', () => {
                 const bytes = Amino.base64ToBytes(txData);
                 const value = Amino.unmarshalTx(bytes, true);
                 expect(value).toMatchObject(tx);
+            });
+        });
+
+        describe('TxBurn', () => {
+            it('decodes bytes', () => {
+                const bytes = Amino.base64ToBytes(burnTxData);
+                const value = Amino.unmarshalTx(bytes, true);
+                expect(value).toMatchObject(burnTx);
             });
         });
     });
@@ -46,6 +98,14 @@ describe('Extensions', () => {
                 const bytes = Amino.marshalTx(tx, true);
                 const data  = Amino.bytesToBase64(bytes);
                 expect(data).toBe(txData);
+            });
+        });
+
+        describe('TxBurn', () => {
+            it('encodes value', () => {
+                const bytes = Amino.marshalTx(burnTx, true);
+                const data  = Amino.bytesToBase64(bytes);
+                expect(data).toBe(burnTxData);
             });
         });
     });

--- a/test/extensions.test.ts
+++ b/test/extensions.test.ts
@@ -1,37 +1,8 @@
 import * as Amino from '../';
 
-const txData = 'lwHwYl3uCh+ISBeyChRXmZp0ijNn4Ck45U3Dn8935ucetBIDeHl6EgQQwIQ9GmoKJuta6YchAzLLqrGgOXVl8+8m3O9tiZdKb4+gQzLloFrMRVmRbBsXEkCeEfjb2IvhUPcricANV/yyMPst0/O64zndCsGH3ywQ0izw1Sk8k1NRD3PFAWJ1YRoUUGM/XbHvh+k7GzKnCZbn';
+const txData = 'ughWYOfsCrMICkBDNTI1MUI4Rjg4QUYyMzZDQzVFNzVDQjc3NzhEMjFDRjFDQzEzNTZEOTA2QTVDNjVGMUJEQ0Q1Mzk2MTVFRjMxEJeeBCKZBhqWBlt7Im1zZ19pbmRleCI6MCwic3VjY2VzcyI6dHJ1ZSwibG9nIjoiIiwiZXZlbnRzIjpbeyJ0eXBlIjoiYnVybiIsImF0dHJpYnV0ZXMiOlt7ImtleSI6ImV0aGVyZXVtX2NoYWluX2lkIiwidmFsdWUiOiIzIn0seyJrZXkiOiJ0b2tlbl9jb250cmFjdCIsInZhbHVlIjoiMHg2ODJjMkFFNDA1M0VhYzY0Y0YxQkFhQTA0QzczOTcwM0RjMDQzRjBBIn0seyJrZXkiOiJjb3Ntb3Nfc2VuZGVyIiwidmFsdWUiOiJjb3Ntb3MxcXdudzJyOWFrNzk1MzZjNGRxdHJ0azJwbDJubHpwcWg3NjNybHMifSx7ImtleSI6ImV0aGVyZXVtX3JlY2VpdmVyIiwidmFsdWUiOiIweDdCOTVCNkVDN0ViRDczNTcyMjk4Y0VmMzJCYjU0RkE0MDgyMDczNTkifSx7ImtleSI6ImFtb3VudCIsInZhbHVlIjoiMXN0YWtlIn1dfSx7InR5cGUiOiJtZXNzYWdlIiwiYXR0cmlidXRlcyI6W3sia2V5Ijoic2VuZGVyIiwidmFsdWUiOiJjb3Ntb3MxcXdudzJyOWFrNzk1MzZjNGRxdHJ0azJwbDJubHpwcWg3NjNybHMifSx7ImtleSI6Im1vZHVsZSIsInZhbHVlIjoiZXRoYnJpZGdlIn0seyJrZXkiOiJzZW5kZXIiLCJ2YWx1ZSI6ImNvc21vczFxd253MnI5YWs3OTUzNmM0ZHF0cnRrMnBsMm5senBxaDc2M3JscyJ9LHsia2V5IjoiYWN0aW9uIiwidmFsdWUiOiJidXJuIn1dfSx7InR5cGUiOiJ0cmFuc2ZlciIsImF0dHJpYnV0ZXMiOlt7ImtleSI6InJlY2lwaWVudCIsInZhbHVlIjoiY29zbW9zMWwzZGZ0ZjQ5OXU0Z3ZkZXV1emRsMnBndjRmMHhkdG51ZW5zNXd2In0seyJrZXkiOiJhbW91bnQiLCJ2YWx1ZSI6IjFzdGFrZSJ9XX1dfV0qzgHMASgoFqkKVID+h3cIAxIUaCwq5AU+rGTPG6qgTHOXA9wEPwoaFAOm5Qy9t4tI6xVoFjXZQfqn8QQXIhR7lbbsfr1zVyKYzvMrtU+kCCBzWSoKCgVzdGFrZRIBMRIEEMCaDBpqCibrWumHIQLSd46NU8TNPq5KoiQ5gsf1NOEc570jHMOI5iOsRLIc1BJAVb3H8EYCymIjOpGOXRQc/yUpdU0Uneyin+xkE2ZSdhxabP/8VVHl+wq5bmcPKH8xX2DqJDEFag9pu/rZfwSRvA=='
 
 const tx = {
-    'type':  'auth/StdTx',
-    'value': {
-        'msg':        [{
-            'type':  'microtick/CreateMarket',
-            'value': {
-                'Account': 'cosmos127ve5ay2xdn7q2fcu4xu8870wlnww845pv6ten',
-                'Market':  'xyz'
-            }
-        }],
-        'fee':        {
-            'amount': null,
-            'gas':    '1000000'
-        },
-        'signatures': [
-            {
-                'signature': 'nhH429iL4VD3K4nADVf8sjD7LdPzuuM53QrBh98sENIs8NUpPJNTUQ9zxQFidWEaFFBjP12x74fpOxsypwmW5w==',
-                'pub_key':   {
-                    'type':  'tendermint/PubKeySecp256k1',
-                    'value': 'AzLLqrGgOXVl8+8m3O9tiZdKb4+gQzLloFrMRVmRbBsX'
-                }
-            }
-        ],
-        'memo':       ''
-    }
-};
-
-const burnTxData = 'ughWYOfsCrMICkBDNTI1MUI4Rjg4QUYyMzZDQzVFNzVDQjc3NzhEMjFDRjFDQzEzNTZEOTA2QTVDNjVGMUJEQ0Q1Mzk2MTVFRjMxEJeeBCKZBhqWBlt7Im1zZ19pbmRleCI6MCwic3VjY2VzcyI6dHJ1ZSwibG9nIjoiIiwiZXZlbnRzIjpbeyJ0eXBlIjoiYnVybiIsImF0dHJpYnV0ZXMiOlt7ImtleSI6ImV0aGVyZXVtX2NoYWluX2lkIiwidmFsdWUiOiIzIn0seyJrZXkiOiJ0b2tlbl9jb250cmFjdCIsInZhbHVlIjoiMHg2ODJjMkFFNDA1M0VhYzY0Y0YxQkFhQTA0QzczOTcwM0RjMDQzRjBBIn0seyJrZXkiOiJjb3Ntb3Nfc2VuZGVyIiwidmFsdWUiOiJjb3Ntb3MxcXdudzJyOWFrNzk1MzZjNGRxdHJ0azJwbDJubHpwcWg3NjNybHMifSx7ImtleSI6ImV0aGVyZXVtX3JlY2VpdmVyIiwidmFsdWUiOiIweDdCOTVCNkVDN0ViRDczNTcyMjk4Y0VmMzJCYjU0RkE0MDgyMDczNTkifSx7ImtleSI6ImFtb3VudCIsInZhbHVlIjoiMXN0YWtlIn1dfSx7InR5cGUiOiJtZXNzYWdlIiwiYXR0cmlidXRlcyI6W3sia2V5Ijoic2VuZGVyIiwidmFsdWUiOiJjb3Ntb3MxcXdudzJyOWFrNzk1MzZjNGRxdHJ0azJwbDJubHpwcWg3NjNybHMifSx7ImtleSI6Im1vZHVsZSIsInZhbHVlIjoiZXRoYnJpZGdlIn0seyJrZXkiOiJzZW5kZXIiLCJ2YWx1ZSI6ImNvc21vczFxd253MnI5YWs3OTUzNmM0ZHF0cnRrMnBsMm5senBxaDc2M3JscyJ9LHsia2V5IjoiYWN0aW9uIiwidmFsdWUiOiJidXJuIn1dfSx7InR5cGUiOiJ0cmFuc2ZlciIsImF0dHJpYnV0ZXMiOlt7ImtleSI6InJlY2lwaWVudCIsInZhbHVlIjoiY29zbW9zMWwzZGZ0ZjQ5OXU0Z3ZkZXV1emRsMnBndjRmMHhkdG51ZW5zNXd2In0seyJrZXkiOiJhbW91bnQiLCJ2YWx1ZSI6IjFzdGFrZSJ9XX1dfV0qzgHMASgoFqkKVID+h3cIAxIUaCwq5AU+rGTPG6qgTHOXA9wEPwoaFAOm5Qy9t4tI6xVoFjXZQfqn8QQXIhR7lbbsfr1zVyKYzvMrtU+kCCBzWSoKCgVzdGFrZRIBMRIEEMCaDBpqCibrWumHIQLSd46NU8TNPq5KoiQ5gsf1NOEc570jHMOI5iOsRLIc1BJAVb3H8EYCymIjOpGOXRQc/yUpdU0Uneyin+xkE2ZSdhxabP/8VVHl+wq5bmcPKH8xX2DqJDEFag9pu/rZfwSRvA=='
-
-const burnTx = {
     'type':  'bridge/BridgeTx',
     'value': {
         "hash": "C5251B8F88AF236CC5E75CB7778D21CF1CC1356D906A5C65F1BDCD539615EF31",
@@ -94,16 +65,8 @@ describe('Extensions', () => {
         describe('Tx', () => {
             it('decodes bytes', () => {
                 const bytes = Amino.base64ToBytes(txData);
-                const value = Amino.unmarshalTx(bytes, true);
-                expect(value).toMatchObject(tx);
-            });
-        });
-
-        describe('TxBurn', () => {
-            it('decodes bytes', () => {
-                const bytes = Amino.base64ToBytes(burnTxData);
                 const value = Amino.unmarshalBridgeTx(bytes, true);
-                expect(value).toMatchObject(burnTx);
+                expect(value).toMatchObject(tx);
             });
         });
     });
@@ -111,17 +74,9 @@ describe('Extensions', () => {
     describe('encoding', () => {
         describe('Tx', () => {
             it('encodes value', () => {
-                const bytes = Amino.marshalTx(tx, true);
+                const bytes = Amino.marshalBridgeTx(tx, true);
                 const data  = Amino.bytesToBase64(bytes);
                 expect(data).toBe(txData);
-            });
-        });
-
-        describe('TxBurn', () => {
-            it('encodes value', () => {
-                const bytes = Amino.marshalBridgeTx(burnTx, true);
-                const data  = Amino.bytesToBase64(bytes);
-                expect(data).toBe(burnTxData);
             });
         });
     });

--- a/test/extensions.test.ts
+++ b/test/extensions.test.ts
@@ -29,47 +29,63 @@ const tx = {
     }
 };
 
-const burnTxData = 'zAEoKBapClSA/od3CAMSFGgsKuQFPqxkzxuqoExzlwPcBD8KGhQDpuUMvbeLSOsVaBY12UH6p/EEFyIUe5W27H69c1cimM7zK7VPpAggc1kqCgoFc3Rha2USATESBBDAmgwaagom61rphyEC0neOjVPEzT6uSqIkOYLH9TThHOe9IxzDiOYjrESyHNQSQFW9x/BGAspiIzqRjl0UHP8lKXVNFJ3sop/sZBNmUnYcWmz//FVR5fsKuW5nDyh/MV9g6iQxBWoPabv62X8Ekbw=';
+const burnTxData = 'ughWYOfsCrMICkBDNTI1MUI4Rjg4QUYyMzZDQzVFNzVDQjc3NzhEMjFDRjFDQzEzNTZEOTA2QTVDNjVGMUJEQ0Q1Mzk2MTVFRjMxEJeeBCKZBhqWBlt7Im1zZ19pbmRleCI6MCwic3VjY2VzcyI6dHJ1ZSwibG9nIjoiIiwiZXZlbnRzIjpbeyJ0eXBlIjoiYnVybiIsImF0dHJpYnV0ZXMiOlt7ImtleSI6ImV0aGVyZXVtX2NoYWluX2lkIiwidmFsdWUiOiIzIn0seyJrZXkiOiJ0b2tlbl9jb250cmFjdCIsInZhbHVlIjoiMHg2ODJjMkFFNDA1M0VhYzY0Y0YxQkFhQTA0QzczOTcwM0RjMDQzRjBBIn0seyJrZXkiOiJjb3Ntb3Nfc2VuZGVyIiwidmFsdWUiOiJjb3Ntb3MxcXdudzJyOWFrNzk1MzZjNGRxdHJ0azJwbDJubHpwcWg3NjNybHMifSx7ImtleSI6ImV0aGVyZXVtX3JlY2VpdmVyIiwidmFsdWUiOiIweDdCOTVCNkVDN0ViRDczNTcyMjk4Y0VmMzJCYjU0RkE0MDgyMDczNTkifSx7ImtleSI6ImFtb3VudCIsInZhbHVlIjoiMXN0YWtlIn1dfSx7InR5cGUiOiJtZXNzYWdlIiwiYXR0cmlidXRlcyI6W3sia2V5Ijoic2VuZGVyIiwidmFsdWUiOiJjb3Ntb3MxcXdudzJyOWFrNzk1MzZjNGRxdHJ0azJwbDJubHpwcWg3NjNybHMifSx7ImtleSI6Im1vZHVsZSIsInZhbHVlIjoiZXRoYnJpZGdlIn0seyJrZXkiOiJzZW5kZXIiLCJ2YWx1ZSI6ImNvc21vczFxd253MnI5YWs3OTUzNmM0ZHF0cnRrMnBsMm5senBxaDc2M3JscyJ9LHsia2V5IjoiYWN0aW9uIiwidmFsdWUiOiJidXJuIn1dfSx7InR5cGUiOiJ0cmFuc2ZlciIsImF0dHJpYnV0ZXMiOlt7ImtleSI6InJlY2lwaWVudCIsInZhbHVlIjoiY29zbW9zMWwzZGZ0ZjQ5OXU0Z3ZkZXV1emRsMnBndjRmMHhkdG51ZW5zNXd2In0seyJrZXkiOiJhbW91bnQiLCJ2YWx1ZSI6IjFzdGFrZSJ9XX1dfV0qzgHMASgoFqkKVID+h3cIAxIUaCwq5AU+rGTPG6qgTHOXA9wEPwoaFAOm5Qy9t4tI6xVoFjXZQfqn8QQXIhR7lbbsfr1zVyKYzvMrtU+kCCBzWSoKCgVzdGFrZRIBMRIEEMCaDBpqCibrWumHIQLSd46NU8TNPq5KoiQ5gsf1NOEc570jHMOI5iOsRLIc1BJAVb3H8EYCymIjOpGOXRQc/yUpdU0Uneyin+xkE2ZSdhxabP/8VVHl+wq5bmcPKH8xX2DqJDEFag9pu/rZfwSRvA=='
 
 const burnTx = {
-    'type':  'bridge/TxBridgeEventData',
+    'type':  'bridge/BridgeTx',
     'value': {
-        'msg':        [{
-            'type':  'bridge/MsgTransfer',
-            'value': {
-                'recipient': 'cosmos1l3dftf499u4gvdeuuzdl2pgv4f0xdtnuens5wv',
-                'amount':  '1stake'
-            }
+        "hash": "C5251B8F88AF236CC5E75CB7778D21CF1CC1356D906A5C65F1BDCD539615EF31",
+        "height": "69399",
+        "index": 0,
+        "tx_result": {
+            "code": 0,
+            "data": null,
+            "log": "[{\"msg_index\":0,\"success\":true,\"log\":\"\",\"events\":[{\"type\":\"burn\",\"attributes\":[{\"key\":\"ethereum_chain_id\",\"value\":\"3\"},{\"key\":\"token_contract\",\"value\":\"0x682c2AE4053Eac64cF1BAaA04C739703Dc043F0A\"},{\"key\":\"cosmos_sender\",\"value\":\"cosmos1qwnw2r9ak79536c4dqtrtk2pl2nlzpqh763rls\"},{\"key\":\"ethereum_receiver\",\"value\":\"0x7B95B6EC7EbD73572298cEf32Bb54FA408207359\"},{\"key\":\"amount\",\"value\":\"1stake\"}]},{\"type\":\"message\",\"attributes\":[{\"key\":\"sender\",\"value\":\"cosmos1qwnw2r9ak79536c4dqtrtk2pl2nlzpqh763rls\"},{\"key\":\"module\",\"value\":\"ethbridge\"},{\"key\":\"sender\",\"value\":\"cosmos1qwnw2r9ak79536c4dqtrtk2pl2nlzpqh763rls\"},{\"key\":\"action\",\"value\":\"burn\"}]},{\"type\":\"transfer\",\"attributes\":[{\"key\":\"recipient\",\"value\":\"cosmos1l3dftf499u4gvdeuuzdl2pgv4f0xdtnuens5wv\"},{\"key\":\"amount\",\"value\":\"1stake\"}]}]}]",
+            "info": "",
+            "gasWanted": "200000",
+            "gasUsed": "64791",
+            "events": [
+                {
+                    'type':  'bridge/MsgTransfer',
+                    'value': {
+                        'recipient': 'cosmos1l3dftf499u4gvdeuuzdl2pgv4f0xdtnuens5wv',
+                        'amount':  '1stake'
+                    }
+                },
+                {
+                    'type':  'bridge/MsgSender',
+                    'value': {
+                        'sender': 'cosmos1qwnw2r9ak79536c4dqtrtk2pl2nlzpqh763rls'      
+                    }
+                },
+                {
+                    'type':  'bridge/MsgModule',
+                    'value': {
+                        'module': 'ethbridge',      
+                        'sender': 'cosmos1qwnw2r9ak79536c4dqtrtk2pl2nlzpqh763rls'      
+                    }
+                },
+                {
+                    'type':  'bridge/MsgBurn',
+                    'value': {
+                        'amount':  '1stake',
+                        // TODO: Change cosmos_sender type to ValAddress to support original 'cosmos1qwnw2r9ak79536c4dqtrtk2pl2nlzpqh763rls',
+                        'cosmos_sender':  'cosmos1h806c7khnvmjlywdrkdgk2vrayy2mmvf9rxk2r',
+                        'ethereum_chain_id': '3',
+                        'ethereum_receiver':  '0x7B95B6EC7EbD73572298cEf32Bb54FA408207359',
+                        'token_contract':  '0x682c2AE4053Eac64cF1BAaA04C739703Dc043F0A'
+                    }
+                },
+                {
+                    'type':  'bridge/MsgAction',
+                    'value': {
+                        'action': 'burn' 
+                    }
+                }
+            ],
+            "codespace": ""
         },
-        {
-            'type':  'bridge/MsgSender',
-            'value': {
-                'sender': 'cosmos1qwnw2r9ak79536c4dqtrtk2pl2nlzpqh763rls'      
-            }
-        },
-        {
-            'type':  'bridge/MsgModule',
-            'value': {
-                'module': 'ethbridge',      
-                'sender': 'cosmos1qwnw2r9ak79536c4dqtrtk2pl2nlzpqh763rls'      
-            }
-        },
-        {
-            'type':  'bridge/MsgBurn',
-            'value': {
-                'EthereumChainID': '3',
-                'TokenContract':  '0x682c2AE4053Eac64cF1BAaA04C739703Dc043F0A',
-                'CosmosSender':  'cosmos1qwnw2r9ak79536c4dqtrtk2pl2nlzpqh763rls',
-                'EthereumReceiver':  '0x7B95B6EC7EbD73572298cEf32Bb54FA408207359',
-                'Amount':  '1stake'
-            }
-        },
-        {
-            'type':  'bridge/MsgAction',
-            'value': {
-                'action': 'burn' 
-            }
-        }]
+        'tx': 'zAEoKBapClSA/od3CAMSFGgsKuQFPqxkzxuqoExzlwPcBD8KGhQDpuUMvbeLSOsVaBY12UH6p/EEFyIUe5W27H69c1cimM7zK7VPpAggc1kqCgoFc3Rha2USATESBBDAmgwaagom61rphyEC0neOjVPEzT6uSqIkOYLH9TThHOe9IxzDiOYjrESyHNQSQFW9x/BGAspiIzqRjl0UHP8lKXVNFJ3sop/sZBNmUnYcWmz//FVR5fsKuW5nDyh/MV9g6iQxBWoPabv62X8Ekbw='
     }
 };
 
@@ -86,7 +102,7 @@ describe('Extensions', () => {
         describe('TxBurn', () => {
             it('decodes bytes', () => {
                 const bytes = Amino.base64ToBytes(burnTxData);
-                const value = Amino.unmarshalTx(bytes, true);
+                const value = Amino.unmarshalBridgeTx(bytes, true);
                 expect(value).toMatchObject(burnTx);
             });
         });
@@ -103,7 +119,7 @@ describe('Extensions', () => {
 
         describe('TxBurn', () => {
             it('encodes value', () => {
-                const bytes = Amino.marshalTx(burnTx, true);
+                const bytes = Amino.marshalBridgeTx(burnTx, true);
                 const data  = Amino.bytesToBase64(bytes);
                 expect(data).toBe(burnTxData);
             });


### PR DESCRIPTION
This PR contains a generic structure for Bridge transactions and includes commentary on other attempted tx structures for Bridge messages (MsgBurn, etc.). The original tx data is included at the bottom of the PR for reference.

**1. Type `auth/StdTx` (as seen with `microtick/CreateMarket`)**
StdTx has fields that the BridgeTx does not (Msgs, Fee, Signatures, Memo).

**2. `[]json.RawMessage` field named 'events'**
```
type BridgeTx struct {
	Events []json.RawMessage `json:"events,omitempty"`
}
```
Initially, I was able to get quite far and successfully pass tests using `json.RawMessage`. However, the RawMessage approach seems much too generic.

**3. `EventDataTx`**
EventDataTx, which includes `TxResult` and `abci.ResponseDeliverTx` seems to be the best fit for our BridgeTx, but named field `tags` doesn't match named field `events` and doesn't pass tests.

So, the `BridgeTx` in this PR is basically `EventDataTx` with the named field `tags` renamed to `events`. However, is quite redundant and gives its own typing error with the current test. There's got to be a simpler way to structure the BridgeTx such that generic Tendermint event data matches up with our existing structure/named fields. How should this ideal BridgeTx be constructed in light of the above considerations?

**Steps for the generation of the sample tx containing MsgBurn occurred as follows:** 

1. BridgeTx containing MsgBurn was generated locally on the bridge blockchain

2. Tx was queried with ```http://localhost:26657/tx?hash=0xC5251B8F88AF236CC5E75CB7778D21CF1CC1356D906A5C65F1BDCD539615EF31```

3. Result of the query. This information is used in 'burnTxData', and 'burnTx' (with decoded message attributes):
```
{
  "jsonrpc": "2.0",
  "id": "",
  "result": {
    "hash": "C5251B8F88AF236CC5E75CB7778D21CF1CC1356D906A5C65F1BDCD539615EF31",
    "height": "69399",
    "index": 0,
    "tx_result": {
      "code": 0,
      "data": null,
      "log": "[{\"msg_index\":0,\"success\":true,\"log\":\"\",\"events\":[{\"type\":\"burn\",\"attributes\":[{\"key\":\"ethereum_chain_id\",\"value\":\"3\"},{\"key\":\"token_contract\",\"value\":\"0x682c2AE4053Eac64cF1BAaA04C739703Dc043F0A\"},{\"key\":\"cosmos_sender\",\"value\":\"cosmos1qwnw2r9ak79536c4dqtrtk2pl2nlzpqh763rls\"},{\"key\":\"ethereum_receiver\",\"value\":\"0x7B95B6EC7EbD73572298cEf32Bb54FA408207359\"},{\"key\":\"amount\",\"value\":\"1stake\"}]},{\"type\":\"message\",\"attributes\":[{\"key\":\"sender\",\"value\":\"cosmos1qwnw2r9ak79536c4dqtrtk2pl2nlzpqh763rls\"},{\"key\":\"module\",\"value\":\"ethbridge\"},{\"key\":\"sender\",\"value\":\"cosmos1qwnw2r9ak79536c4dqtrtk2pl2nlzpqh763rls\"},{\"key\":\"action\",\"value\":\"burn\"}]},{\"type\":\"transfer\",\"attributes\":[{\"key\":\"recipient\",\"value\":\"cosmos1l3dftf499u4gvdeuuzdl2pgv4f0xdtnuens5wv\"},{\"key\":\"amount\",\"value\":\"1stake\"}]}]}]",
      "info": "",
      "gasWanted": "200000",
      "gasUsed": "64791",
      "events": [
        {
          "type": "transfer",
          "attributes": [
            {
              "key": "cmVjaXBpZW50",
              "value": "Y29zbW9zMWwzZGZ0ZjQ5OXU0Z3ZkZXV1emRsMnBndjRmMHhkdG51ZW5zNXd2"
            },
            {
              "key": "YW1vdW50",
              "value": "MXN0YWtl"
            }
          ]
        },
        {
          "type": "message",
          "attributes": [
            {
              "key": "c2VuZGVy",
              "value": "Y29zbW9zMXF3bncycjlhazc5NTM2YzRkcXRydGsycGwybmx6cHFoNzYzcmxz"
            }
          ]
        },
        {
          "type": "message",
          "attributes": [
            {
              "key": "bW9kdWxl",
              "value": "ZXRoYnJpZGdl"
            },
            {
              "key": "c2VuZGVy",
              "value": "Y29zbW9zMXF3bncycjlhazc5NTM2YzRkcXRydGsycGwybmx6cHFoNzYzcmxz"
            }
          ]
        },
        {
          "type": "burn",
          "attributes": [
            {
              "key": "ZXRoZXJldW1fY2hhaW5faWQ=",
              "value": "Mw=="
            },
            {
              "key": "dG9rZW5fY29udHJhY3Q=",
              "value": "MHg2ODJjMkFFNDA1M0VhYzY0Y0YxQkFhQTA0QzczOTcwM0RjMDQzRjBB"
            },
            {
              "key": "Y29zbW9zX3NlbmRlcg==",
              "value": "Y29zbW9zMXF3bncycjlhazc5NTM2YzRkcXRydGsycGwybmx6cHFoNzYzcmxz"
            },
            {
              "key": "ZXRoZXJldW1fcmVjZWl2ZXI=",
              "value": "MHg3Qjk1QjZFQzdFYkQ3MzU3MjI5OGNFZjMyQmI1NEZBNDA4MjA3MzU5"
            },
            {
              "key": "YW1vdW50",
              "value": "MXN0YWtl"
            }
          ]
        },
        {
          "type": "message",
          "attributes": [
            {
              "key": "YWN0aW9u",
              "value": "YnVybg=="
            }
          ]
        }
      ],
      "codespace": ""
    },
    "tx": "zAEoKBapClSA/od3CAMSFGgsKuQFPqxkzxuqoExzlwPcBD8KGhQDpuUMvbeLSOsVaBY12UH6p/EEFyIUe5W27H69c1cimM7zK7VPpAggc1kqCgoFc3Rha2USATESBBDAmgwaagom61rphyEC0neOjVPEzT6uSqIkOYLH9TThHOe9IxzDiOYjrESyHNQSQFW9x/BGAspiIzqRjl0UHP8lKXVNFJ3sop/sZBNmUnYcWmz//FVR5fsKuW5nDyh/MV9g6iQxBWoPabv62X8Ekbw="
  }
}
```